### PR TITLE
feat: Uses ics.Calendar.serialize instead of __str__.

### DIFF
--- a/icsmerger/merge.py
+++ b/icsmerger/merge.py
@@ -54,7 +54,7 @@ def save_calendar(calendar: ics.Calendar, out: str) -> None:
     Saves the calendar to a file.
     """
     with open(out, "w") as f:
-        f.write(str(calendar))
+        f.write(calendar.serialize())
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/icsmerger/tests/save_calendar_test.py
+++ b/icsmerger/tests/save_calendar_test.py
@@ -11,7 +11,7 @@ class TestSaveCalendar(unittest.TestCase):
     def test_save(self, calendar_mock: unittest.mock.MagicMock, open_mock: unittest.mock.MagicMock):
         expected_out = "calendar.ics"
         expected_write = "ics data"
-        calendar_mock.__str__ = unittest.mock.MagicMock(
+        calendar_mock.serialize = unittest.mock.MagicMock(
             return_value=expected_write)
         merge.save_calendar(calendar_mock, expected_out)
         open_mock.assert_called_with(expected_out, "w")


### PR DESCRIPTION
ics.Calendar.__str__ throws a future warning.
See https://github.com/ics-py/ics-py/commit/f64c112dbacb2a49ad2ca53de8c579b5710ce992.