### PR TITLE
chore: Sets container base image to Python 3.11.4 and Alpine 3.18.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/python:3.11-alpine
+FROM docker.io/python:3.11.4-alpine3.18
 
 RUN apk add --no-cache git
 


### PR DESCRIPTION
# Changes

- Sets container base image to Python 3.11.4 on Alpine 3.18.