### PR TITLE
feat: Mitigate TatSu's dropping of Python 3.10 support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ idna==3.4
 python-dateutil==2.8.2
 requests==2.31.0
 six==1.16.0
-TatSu==5.8.3
+TatSu==5.8.3; python_version < '3.11'
+TatSu>=5.9.2; python_version > '3.10'
 urllib3==2.0.7


### PR DESCRIPTION
Mitigation for #55 using environment markers in requirements.txt.