### PR TITLE
feat: Adds support for Python 3.13, removes support for Python 3.9.

### DIFF
--- a/.github/workflows/ci-qa-pipeline.yml
+++ b/.github/workflows/ci-qa-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-qa-pipeline.yml
+++ b/.github/workflows/ci-qa-pipeline.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         language: ["python"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         language: ["python"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This is a list of notable changes to the project.
 
 ## Development
 
+- Adds support for Python 3.13.
 - Removes support for Python 3.9.
 
 ## [v1.0.7] - 2024-12-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This is a list of notable changes to the project.
 
+## Development
+
+- Removes support for Python 3.9.
+
 ## [v1.0.7] - 2024-12-23
 
 - Bump urllib3 from 2.2.3 to 2.3.0 (#118)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A script to download and merge multiple online ICS resources into one ICS.
 There are threw ways to run this script.
 Call the console script, via Python or using Docker.
 
+### Requirements
+
+- Python >= 3.10
+
 ### Console script
 
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: OS Independent
-    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Internet
     Topic :: Office/Business :: Scheduling
 description = A script to download and merge multiple online ICS resources into one ICS.
@@ -24,7 +24,7 @@ install_requires =
 package_dir =
     = .
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.10
 tests_require=
     pytest == 8.3.5
     pytest-cov == 6.2.1


### PR DESCRIPTION
# Removes support for Python 3.9

- Removes support for Python 3.9, will be EOL "soon".
- See PR #137.
- Click >= 8.2.0 drops support for Python 3.9, see https://github.com/pallets/click/releases/tag/8.2.0

# Adds support for Python 3.13

- Adds Python 3.13 to workflows.