### PR TITLE
chore(github): #174: Removes deprecated CODEQL_PYTHON and setup-python-dependencies.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,13 +36,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip;
           pip install -r requirements.txt;
-          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          setup-python-dependencies: false
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4


### PR DESCRIPTION
Removes deprecated environment variable CODEQL_PYTHON and setup-python-dependencies.

See

- https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/
- https://github.com/github/codeql-action/pull/2224

Closes #174